### PR TITLE
Fix smhd - missing reserved field

### DIFF
--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -626,7 +626,8 @@ SoundMediaHeaderBox = Struct(
     "type" / Const(b"smhd"),
     "version" / Const(Int8ub, 0),
     "flags" / Const(Int24ub, 0),
-    "balance" / Default(Int16sb, 0)
+    "balance" / Default(Int16sb, 0),
+    Const(Int16ub, 0),
 )
 
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -103,3 +103,19 @@ class BoxTests(unittest.TestCase):
             b'\x00\x00\x00\x20trex\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
             b'\x00\x00\x00\x20trex\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
         )
+
+    def test_smhd_parse(self):
+        in_bytes = b'\x00\x00\x00\x10smhd\x00\x00\x00\x00\x00\x00\x00\x00'
+        self.assertEqual(
+            Box.parse(in_bytes + b'padding'),
+            Container(offset=0)
+            (type=b"smhd")(version=0)(flags=0)
+            (balance=0)(end=len(in_bytes))
+        )
+
+    def test_smhd_build(self):
+        smhd_data = Box.build(dict(
+            type=b"smhd",
+            balance=0))
+        self.assertEqual(len(smhd_data), 16),
+        self.assertEqual(smhd_data, b'\x00\x00\x00\x10smhd\x00\x00\x00\x00\x00\x00\x00\x00')


### PR DESCRIPTION
Added padding bytes in test to verify only expected bytes read

Test fails if the change to parser is reverted, the smhd box is from a working mp4.