### PR TITLE
Construct upgrade to 2.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ all: test
 env/bin/activate: 
 	test -d env || python3 -m venv env
 	. env/bin/activate; \
-		pip3 install -r requirements.txt
+	pip3 install wheel; \
+	python3 setup.py bdist_wheel; \
+	pip3 install -r requirements.txt
 
 env: env/bin/activate
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# vim:noexpandtab:sw=2 ts=2
+
+.PHONY: env
+
+all: test
+
+env/bin/activate: 
+	test -d env || python3 -m venv env
+	. env/bin/activate; \
+		pip3 install -r requirements.txt
+
+env: env/bin/activate
+
+test: env
+	. env/bin/activate; \
+	coverage3 run -m pytest -s -v
+
+clean:
+	rm -rf env
+	find . -name "*pycache*" -exec rm -fr "{}" \;

--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ Defects / Next steps:
   to be allow a more coherent usage.
 - add new tests to cover all applied changes
 
+## Test
+
+Just run ```make``` to build a virtual env and run tests.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,48 @@ Container:
         avc1
 
 ```
+
+# Upgrade to Construct 2.10
+
+The current master of pymp4 is based on construct v2.8.8. This is an old
+version (years ago): it does not have a public doc page, several improvements
+have been introduced and the general consensus seems to point to an upgrade.
+
+Unfortunately several breaking changes have been introduced, making the
+transition harder. Construct's doc does not help very much either.
+
+This is a first attempt at building pymp4 based on construct v 2.10.60. There
+have been no attempts to parse an actual mp4 file with it, this is just a first
+pass to understand the implications of this migration.
+
+The most important impacts seems to be:
+
+- changed all String classes to PaddedString
+- using new argument order for Const
+- replaced custom "Prefixedincludedsize" class with the new "Prefixed" one,
+  supporting the case where length field accounts for its own length
+- adjusted offsets/end field calculation based on the different way the
+  Prefixed class work
+- getting rid of all "Embedded" structs (entirely deprecated and removed from
+  construct 2.10), in favour of "named", nested structs.
+
+All tests are passing, but no effort has been made for the moment to make sure
+all applied changes are covered.
+
+The most impacting change is the removal of "Embedded". The change makes it
+harder to use the "Box" structure and introduces an additional "box_body"
+field that seems somehow unnecessary and artificial with respect to what
+obtained by using "Embedded". This becomes quickly annoying especially when
+trying to build or parse boxes with more than a few levels of nesting (have
+a look at how the code in "test_moov_build" changes).
+
+It is possible that "Box" and "ContainerBox" can be redesigned, improving
+usability.
+
+Defects / Next steps:
+
+- some constructs use binary string, other handle standard python (unicode)
+  strings for essentially the same fields. An effort should be made if possible
+  to be allow a more coherent usage.
+- add new tests to cover all applied changes
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+construct
+pytest
+coverage

--- a/setup.py
+++ b/setup.py
@@ -19,35 +19,35 @@ from os.path import abspath, dirname, join
 from setuptools import setup, find_packages
 from sys import path as sys_path
 
-deps = [
-    "construct==2.8.8"
-]
+deps = ["construct"]
 
 srcdir = join(dirname(abspath(__file__)), "src/")
 sys_path.insert(0, srcdir)
 
-setup(name="pymp4",
-      version="1.2.0",
-      description="A Python parser for MP4 boxes",
-      url="https://github.com/beardypig/pymp4",
-      author="beardypig",
-      author_email="git@beardypig.com",
-      license="Apache 2.0",
-      packages=find_packages("src"),
-      package_dir={"": "src"},
-      entry_points={
-          "console_scripts": ["mp4dump=pymp4.cli:dump"]
-      },
-      install_requires=deps,
-      test_suite="tests",
-      classifiers=["Development Status :: 4 - Beta",
-                   "Environment :: Console",
-                   "Operating System :: POSIX",
-                   "Programming Language :: Python :: 2.7",
-                   "Programming Language :: Python :: 3.3",
-                   "Programming Language :: Python :: 3.4",
-                   "Programming Language :: Python :: 3.5",
-                   "Programming Language :: Python :: 3.6",
-                   "Topic :: Multimedia :: Sound/Audio",
-                   "Topic :: Multimedia :: Video",
-                   "Topic :: Utilities"])
+setup(
+    name="pymp4",
+    version="1.2.0",
+    description="A Python parser for MP4 boxes",
+    url="https://github.com/beardypig/pymp4",
+    author="beardypig",
+    author_email="git@beardypig.com",
+    license="Apache 2.0",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    entry_points={"console_scripts": ["mp4dump=pymp4.cli:dump"]},
+    install_requires=deps,
+    test_suite="tests",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Multimedia :: Sound/Audio",
+        "Topic :: Multimedia :: Video",
+        "Topic :: Utilities",
+    ],
+)

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -707,14 +707,14 @@ UUIDBox = Struct(
 ContainerBoxLazy = LazyBound(lambda ctx: ContainerBox)
 
 
-class TellMinusSizeOf(Subconstruct):
+class TellPlusSizeOf(Subconstruct):
     def __init__(self, subcon):
-        super(TellMinusSizeOf, self).__init__(subcon)
+        super(TellPlusSizeOf, self).__init__(subcon)
         self.flagbuildnone = True
 
     def _parse(self, stream, context, path):
         import pdb;pdb.set_trace()
-        return stream.tell() - self.subcon.sizeof(context=context)
+        return stream.tell() + self.subcon.sizeof(context=context)
 
     def _build(self, obj, stream, context, path):
         return b""

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -84,22 +84,22 @@ class PrefixedIncludingSize(Subconstruct):
 
 FileTypeBox = Struct(
     "type" / Const(b"ftyp"),
-    "major_brand" / String(4),
+    "major_brand" / PaddedString(4, "utf8"),
     "minor_version" / Int32ub,
-    "compatible_brands" / GreedyRange(String(4)),
+    "compatible_brands" / GreedyRange(PaddedString(4, "utf8")),
 )
 
 SegmentTypeBox = Struct(
     "type" / Const(b"styp"),
-    "major_brand" / String(4),
+    "major_brand" / PaddedString(4, "utf8"),
     "minor_version" / Int32ub,
-    "compatible_brands" / GreedyRange(String(4)),
+    "compatible_brands" / GreedyRange(PaddedString(4, "utf8")),
 )
 
 # Catch find boxes
 
 RawBox = Struct(
-    "type" / String(4, padchar=b" ", paddir="right"),
+    "type" / PaddedString(4, "utf8"),
     "data" / Default(GreedyBytes, b"")
 )
 
@@ -265,7 +265,7 @@ HandlerReferenceBox = Struct(
     "version" / Const(Int8ub, 0),
     "flags" / Const(Int24ub, 0),
     Padding(4, pattern=b"\x00"),
-    "handler_type" / String(4),
+    "handler_type" / PaddedString(4, "utf8"),
     Padding(12, pattern=b"\x00"),  # Int32ub[3]
     "name" / CString(encoding="utf8")
 )
@@ -378,7 +378,7 @@ HVCC = Struct(
 AVC1SampleEntryBox = Struct(
     "version" / Default(Int16ub, 0),
     "revision" / Const(Int16ub, 0),
-    "vendor" / Default(String(4, padchar=b" "), b"brdy"),
+    "vendor" / Default(PaddedString(4, "utf8"), b"brdy"),
     "temporal_quality" / Default(Int32ub, 0),
     "spatial_quality" / Default(Int32ub, 0),
     "width" / Int16ub,
@@ -389,11 +389,11 @@ AVC1SampleEntryBox = Struct(
     Padding(2),
     "data_size" / Const(Int32ub, 0),
     "frame_count" / Default(Int16ub, 1),
-    "compressor_name" / Default(String(32, padchar=b" "), ""),
+    "compressor_name" / Default(PaddedString(32, "utf8"), ""),
     "depth" / Default(Int16ub, 24),
     "color_table_id" / Default(Int16sb, -1),
     "avc_data" / PrefixedIncludingSize(Int32ub, Struct(
-    "type" / String(4, padchar=b" ", paddir="right"),
+    "type" / PaddedString(4, "utf8"),
         Embedded(Switch(this.type, {
             b"avcC": AAVC,
             b"hvcC": HVCC,
@@ -403,7 +403,7 @@ AVC1SampleEntryBox = Struct(
 )
 
 SampleEntryBox = PrefixedIncludingSize(Int32ub, Struct(
-    "format" / String(4, padchar=b" ", paddir="right"),
+    "format" / PaddedString(4, "utf8"),
     Padding(6, pattern=b"\x00"),
     "data_reference_index" / Default(Int16ub, 1),
     Embedded(Switch(this.format, {
@@ -728,14 +728,14 @@ SampleEncryptionBox = Struct(
 
 OriginalFormatBox = Struct(
     "type" / Const(b"frma"),
-    "original_format" / Default(String(4), b"avc1")
+    "original_format" / Default(PaddedString(4, "utf8"), b"avc1")
 )
 
 SchemeTypeBox = Struct(
     "type" / Const(b"schm"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
-    "scheme_type" / Default(String(4), b"cenc"),
+    "scheme_type" / Default(PaddedString(4, "utf8"), b"cenc"),
     "scheme_version" / Default(Int32ub, 0x00010000),
     "schema_uri" / Default(If(this.flags & 1 == 1, CString()), None)
 )
@@ -778,7 +778,7 @@ class TellMinusSizeOf(Subconstruct):
 
 Box = PrefixedIncludingSize(Int32ub, Struct(
     "offset" / TellMinusSizeOf(Int32ub),
-    "type" / Peek(String(4, padchar=b" ", paddir="right")),
+    "type" / Peek(PaddedString(4, "utf8")),
     Embedded(Switch(this.type, {
         b"ftyp": FileTypeBox,
         b"styp": SegmentTypeBox,
@@ -838,7 +838,7 @@ Box = PrefixedIncludingSize(Int32ub, Struct(
 ))
 
 ContainerBox = Struct(
-    "type" / String(4, padchar=b" ", paddir="right"),
+    "type" / PaddedString(4, "utf8"),
     "children" / GreedyRange(Box)
 )
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -26,12 +26,11 @@ log = logging.getLogger(__name__)
 
 class BoxTests(unittest.TestCase):
     def test_ftyp_parse(self):
-        import pdb;pdb.set_trace()
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1'),
             Container(offset=0)
             (type=u"ftyp")
-            (box_body=Container(type=b"ftyp")(major_brand=b"iso5")
+            (box_body=Container(type=b"ftyp")(major_brand="iso5")
             (minor_version=1)
             (compatible_brands=ListContainer(["iso5", "avc1"])))
             (end=24)
@@ -40,10 +39,13 @@ class BoxTests(unittest.TestCase):
     def test_ftyp_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"ftyp",
-                major_brand=b"iso5",
-                minor_version=1,
-                compatible_brands=[b"iso5", b"avc1"])),
+                type="ftyp",
+                box_body=dict(
+                    type=b"ftyp",
+                    major_brand="iso5",
+                    minor_version=1,
+                    compatible_brands=["iso5", "avc1"]))
+            ),
             b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1')
 
     def test_mdhd_parse(self):
@@ -51,48 +53,58 @@ class BoxTests(unittest.TestCase):
             Box.parse(
                 b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00'),
             Container(offset=0)
-            (type=b"mdhd")(version=0)(flags=0)
-            (creation_time=0)
-            (modification_time=0)
-            (timescale=1000000)
-            (duration=0)
-            (language="und")
+            (type=u'mdhd')
+            (box_body=Container(type=b'mdhd')
+                (version=0)
+                (flags=0)
+                (creation_time=0)
+                (modification_time=0)
+                (timescale=1000000)
+                (duration=0)
+                (language=Container(code=u'und'))
+            )
             (end=32)
         )
 
     def test_mdhd_build(self):
         mdhd_data = Box.build(dict(
-            type=b"mdhd",
-            creation_time=0,
-            modification_time=0,
-            timescale=1000000,
-            duration=0,
-            language=u"und"))
+            type="mdhd",
+            box_body = dict(
+                type=b"mdhd",
+                creation_time=0,
+                modification_time=0,
+                timescale=1000000,
+                duration=0,
+                language=dict(code=u"und")))
+        )
         self.assertEqual(len(mdhd_data), 32)
         self.assertEqual(mdhd_data,
                          b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00')
 
         mdhd_data64 = Box.build(dict(
-            type=b"mdhd",
-            version=1,
-            creation_time=0,
-            modification_time=0,
-            timescale=1000000,
-            duration=0,
-            language=u"und"))
+            type="mdhd",
+            box_body = dict(
+                type=b"mdhd",
+                version=1,
+                creation_time=0,
+                modification_time=0,
+                timescale=1000000,
+                duration=0,
+                language=dict(code=u"und")))
+        )
         self.assertEqual(len(mdhd_data64), 44)
         self.assertEqual(mdhd_data64,
                          b'\x00\x00\x00,mdhd\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00\x00\x00\x00\x00U\xc4\x00\x00')
 
     def test_moov_build(self):
         moov = \
-            Container(type=b"moov")(children=[  # 96 bytes
-                Container(type=b"mvex")(children=[  # 88 bytes
-                    Container(type=b"mehd")(version=0)(flags=0)(fragment_duration=0),  # 16 bytes
-                    Container(type=b"trex")(track_ID=1),  # 32 bytes
-                    Container(type=b"trex")(track_ID=2),  # 32 bytes
-                ])
-            ])
+            Container(type="moov")(box_body=Container(type="moov")(children=ListContainer([  # 96 bytes
+                Container(type="mvex")(box_body=Container(type="mvex")(children=ListContainer([  # 88 bytes
+                    Container(type="mehd")(box_body=Container(type=b"mehd")(version=0)(flags=0)(fragment_duration=0)),  # 16 bytes
+                    Container(type="trex")(box_body=Container(type=b"trex")(track_ID=1)),  # 32 bytes
+                    Container(type="trex")(box_body=Container(type=b"trex")(track_ID=2)),  # 32 bytes
+                ])))
+            ])))
 
         moov_data = Box.build(moov)
 
@@ -111,14 +123,18 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(in_bytes + b'padding'),
             Container(offset=0)
-            (type=b"smhd")(version=0)(flags=0)
-            (balance=0)(reserved=0)(end=len(in_bytes))
+            (type=u"smhd")(box_body=Container(type=b"smhd")(version=0)(flags=0)
+            (balance=0)(reserved=0))(end=len(in_bytes))
         )
 
     def test_smhd_build(self):
         smhd_data = Box.build(dict(
-            type=b"smhd",
-            balance=0))
+            type="smhd", box_body = dict( 
+                    type=b"smhd",
+                    balance=0
+                    )
+                )
+            )
         self.assertEqual(len(smhd_data), 16),
         self.assertEqual(smhd_data, b'\x00\x00\x00\x10smhd\x00\x00\x00\x00\x00\x00\x00\x00')
 
@@ -127,8 +143,16 @@ class BoxTests(unittest.TestCase):
         in_bytes = b'\x00\x00\x00\x50stsd\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x40tx3g\x00\x00\x00\x00\x00\x00\x00\x01' + tx3g_data
         self.assertEqual(
             Box.parse(in_bytes + b'padding'),
-            Container(offset=0)
-            (type=b"stsd")(version=0)(flags=0)
-            (entries=[Container(format=b'tx3g')(data_reference_index=1)(data=tx3g_data)])
+            Container(offset=0)(type=u"stsd")
+            (box_body=Container(type=b"stsd")
+                (version=0)
+                (flags=0)
+                (entries=ListContainer(
+                        [Container(format=u'tx3g')
+                              (data_reference_index=1)
+                              (sample_entry_box=Container(data=tx3g_data))
+                        ]
+                    )
+                ))
             (end=len(in_bytes))
         )

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -25,13 +25,14 @@ log = logging.getLogger(__name__)
 
 class BoxTests(unittest.TestCase):
     def test_ftyp_parse(self):
+        import pdb;pdb.set_trace()
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1'),
             Container(offset=0)
             (type=b"ftyp")
-            (major_brand=b"iso5")
+            (box_body=Container(major_brand=b"iso5")
             (minor_version=1)
-            (compatible_brands=[b"iso5", b"avc1"])
+            (compatible_brands=[b"iso5", b"avc1"]))
             (end=24)
         )
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -18,6 +18,7 @@ import logging
 import unittest
 
 from construct import Container
+from construct.lib.containers import ListContainer
 from pymp4.parser import Box
 
 log = logging.getLogger(__name__)
@@ -29,10 +30,10 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1'),
             Container(offset=0)
-            (type=b"ftyp")
-            (box_body=Container(major_brand=b"iso5")
+            (type=u"ftyp")
+            (box_body=Container(type=b"ftyp")(major_brand=b"iso5")
             (minor_version=1)
-            (compatible_brands=[b"iso5", b"avc1"]))
+            (compatible_brands=ListContainer(["iso5", "avc1"])))
             (end=24)
         )
 

--- a/tests/test_dashboxes.py
+++ b/tests/test_dashboxes.py
@@ -29,20 +29,26 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00 tenc\x00\x00\x00\x00\x00\x00\x01\x083{\x96C!\xb6CU\x9eY>\xcc\xb4l~\xf7'),
             Container(offset=0)
-            (type=b"tenc")
-            (version=0)
-            (flags=0)
-            (is_encrypted=1)
-            (iv_size=8)
-            (key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'))
+            (type=u"tenc")
+            (box_body=Container(type=b"tenc")
+                    (version=0)
+                    (flags=0)
+                    (is_encrypted=1)
+                    (iv_size=8)
+                    (key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'))
+                    (constant_iv=None))
             (end=32)
         )
 
     def test_tenc_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"tenc",
-                key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
-                iv_size=8,
-                is_encrypted=1)),
+                type="tenc",
+                box_body=dict(
+                    type=b"tenc",
+                    key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
+                    iv_size=8,
+                    is_encrypted=1,
+                    constant_iv=None))
+            ),
             b'\x00\x00\x00 tenc\x00\x00\x00\x00\x00\x00\x01\x083{\x96C!\xb6CU\x9eY>\xcc\xb4l~\xf7')


### PR DESCRIPTION
Hi,

despite being new to pymp4 and construct, I've decided to give a shot to upgrading to 2.10.60. 

It was a useful learning exercise for me but before I spend any more effort on it, I wanted to get in touch with you. I'm sure you have considered this upgrade in the past and you probably have useful pointers or reason to do/not do it.

In this merge request, I've just focused on introducing as few modifications as possible to pymp4 struct definitions, and have all the included tests pass. I've made no efforts to refactor the struct definitions or to investigate new features available in Construct 2.10, nor in making sure the tests cover all changes, nor I have attempted to parse any "real" mp4. For the moment, I just wanted to understand the impacts of such an upgrade.

The removal of "Embedded" (surely done for good reasons) in particular is in my opinion a bit detrimental to the overall usability of the "Box" and "ContainerBox" structs, with the introduction of unnecessary fields whose presence is only needed to handle the struct nesting. You can immediately spot that just from the changes in the tests source code... unless there is a better way to replace it that I did not understand.

As the author, I'm sure you'll immediately know if this is something worth working on or not.

Thanks, let me know if you can

