### PR TITLE
Upgrade from Construct 2.8.8 to 2.10.68 (All tests pass on 3.10)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -33,14 +33,17 @@ files = [
 
 [[package]]
 name = "construct"
-version = "2.8.8"
-description = "A powerful declarative parser/builder for binary data"
+version = "2.10.68"
+description = "A powerful declarative symmetric parser/builder for binary data"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 files = [
-    {file = "construct-2.8.8.tar.gz", hash = "sha256:1b84b8147f6fd15bcf64b737c3e8ac5100811ad80c830cb4b2545140511c4157"},
+    {file = "construct-2.10.68.tar.gz", hash = "sha256:7b2a3fd8e5f597a5aa1d614c3bd516fa065db01704c72a1efaaeec6ef23d8b45"},
 ]
+
+[package.extras]
+extras = ["arrow", "cloudpickle", "enum34", "lz4", "numpy", "ruamel.yaml"]
 
 [[package]]
 name = "coverage"
@@ -275,4 +278,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "9a2baac6978e2ce64197980dda6b562347469f581c3881b1fe9d59432d47bc51"
+content-hash = "fc4ee9dd83c675556d17d4c93f297cc1c9dc13f756645b08b15155585b2ee984"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-construct = "2.8.8"
+construct = "2.10.68"
 
 [tool.poetry.group.dev.dependencies]
 coverage = { version="^7.2.3", extras=["toml"] }

--- a/src/pymp4/adapters.py
+++ b/src/pymp4/adapters.py
@@ -8,10 +8,18 @@ from construct import Adapter, int2byte
 
 class ISO6392TLanguageCode(Adapter, ABC):
     def _decode(self, obj, context, path):
-        return b"".join(map(int2byte, [c + 0x60 for c in bytearray(obj)])).decode("utf8")
+        return "".join([
+            chr(bit + 0x60)
+            for bit in (
+                (obj >> 10) & 0b11111,
+                (obj >> 5) & 0b11111,
+                obj & 0b11111
+            )
+        ])
 
     def _encode(self, obj, context, path):
-        return [c - 0x60 for c in bytearray(obj.encode("utf8"))]
+        bits = [ord(c) - 0x60 for c in obj]
+        return (bits[0] << 10) | (bits[1] << 5) | bits[2]
 
 
 class MaskedInteger(Adapter, ABC):

--- a/src/pymp4/adapters.py
+++ b/src/pymp4/adapters.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC
+from uuid import UUID
+
+from construct import Adapter, int2byte
+
+
+class ISO6392TLanguageCode(Adapter, ABC):
+    def _decode(self, obj, context, path):
+        return b"".join(map(int2byte, [c + 0x60 for c in bytearray(obj)])).decode("utf8")
+
+    def _encode(self, obj, context, path):
+        return [c - 0x60 for c in bytearray(obj.encode("utf8"))]
+
+
+class MaskedInteger(Adapter, ABC):
+    def _decode(self, obj, context, path):
+        return obj & 0x1F
+
+    def _encode(self, obj, context, path):
+        return obj & 0x1F
+
+
+class UUIDBytes(Adapter, ABC):
+    def _decode(self, obj, context, path):
+        return UUID(bytes=obj)
+
+    def _encode(self, obj, context, path):
+        return obj.bytes

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -20,6 +20,8 @@ from uuid import UUID
 from construct import *
 from construct.lib import *
 
+from pymp4.adapters import ISO6392TLanguageCode, MaskedInteger, UUIDBytes
+
 log = logging.getLogger(__name__)
 
 UNITY_MATRIX = [0x10000, 0, 0, 0, 0x10000, 0, 0, 0, 0x40000000]
@@ -176,20 +178,6 @@ HDSFragmentRunBox = Struct(
 
 # Boxes contained by Media Box
 
-class ISO6392TLanguageCode(Adapter):
-    def _decode(self, obj, context, path):
-        """
-        Get the python representation of the obj
-        """
-        return b''.join(map(int2byte, [c + 0x60 for c in bytearray(obj)])).decode("utf8")
-
-    def _encode(self, obj, context, path):
-        """
-        Get the bytes representation of the obj
-        """
-        return [c - 0x60 for c in bytearray(obj.encode("utf8"))]
-
-
 MediaHeaderBox = Struct(
     "type" / Const(b"mdhd"),
     "version" / Default(Int8ub, 0),
@@ -268,15 +256,6 @@ MP4ASampleEntryBox = Struct(
     "sampling_rate" / Int16ub,
     Padding(2)
 )
-
-
-class MaskedInteger(Adapter):
-    def _decode(self, obj, context, path):
-        return obj & 0x1F
-
-    def _encode(self, obj, context, path):
-        return obj & 0x1F
-
 
 AAVC = Struct(
     "version" / Const(1, Int8ub),
@@ -617,14 +596,6 @@ SoundMediaHeaderBox = Struct(
 
 
 # DASH Boxes
-
-class UUIDBytes(Adapter):
-    def _decode(self, obj, context, path):
-        return UUID(bytes=obj)
-
-    def _encode(self, obj, context, path):
-        return obj.bytes
-
 
 ProtectionSystemHeaderBox = Struct(
     "type" / If(this._.type != "uuid", Const(b"pssh")),

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -177,13 +177,13 @@ HDSFragmentRunBox = Struct(
 # Boxes contained by Media Box
 
 class ISO6392TLanguageCode(Adapter):
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         """
         Get the python representation of the obj
         """
         return b''.join(map(int2byte, [c + 0x60 for c in bytearray(obj)])).decode("utf8")
 
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         """
         Get the bytes representation of the obj
         """
@@ -271,10 +271,10 @@ MP4ASampleEntryBox = Struct(
 
 
 class MaskedInteger(Adapter):
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         return obj & 0x1F
 
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         return obj & 0x1F
 
 
@@ -619,10 +619,10 @@ SoundMediaHeaderBox = Struct(
 # DASH Boxes
 
 class UUIDBytes(Adapter):
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         return UUID(bytes=obj)
 
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         return obj.bytes
 
 

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -651,7 +651,7 @@ UUIDBox = Struct(
     }, GreedyBytes)
 )
 
-ContainerBoxLazy = LazyBound(lambda ctx: ContainerBox)
+ContainerBoxLazy = LazyBound(lambda: ContainerBox)
 
 
 Box = Prefixed(Int32ub, Struct(

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -136,11 +136,11 @@ HDSSegmentBox = Struct(
     "time_scale" / Int32ub,
     "current_media_time" / Int64ub,
     "smpte_time_code_offset" / Int64ub,
-    "movie_identifier" / CString(),
-    "server_entry_table" / PrefixedArray(Int8ub, CString()),
-    "quality_entry_table" / PrefixedArray(Int8ub, CString()),
-    "drm_data" / CString(),
-    "metadata" / CString(),
+    "movie_identifier" / CString("ascii"),
+    "server_entry_table" / PrefixedArray(Int8ub, CString("ascii")),
+    "quality_entry_table" / PrefixedArray(Int8ub, CString("ascii")),
+    "drm_data" / CString("ascii"),
+    "metadata" / CString("ascii"),
     "segment_run_table" / PrefixedArray(Int8ub, LazyBound(lambda x: Box)),
     "fragment_run_table" / PrefixedArray(Int8ub, LazyBound(lambda x: Box))
 )
@@ -149,7 +149,7 @@ HDSSegmentRunBox = Struct(
     "type" / Const(b"asrt"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
-    "quality_entry_table" / PrefixedArray(Int8ub, CString()),
+    "quality_entry_table" / PrefixedArray(Int8ub, CString("ascii")),
     "segment_run_enteries" / PrefixedArray(Int32ub, Struct(
         "first_segment" / Int32ub,
         "fragments_per_segment" / Int32ub
@@ -164,7 +164,7 @@ HDSFragmentRunBox = Struct(
         "update" / Flag
     ),
     "time_scale" / Int32ub,
-    "quality_entry_table" / PrefixedArray(Int8ub, CString()),
+    "quality_entry_table" / PrefixedArray(Int8ub, CString("ascii")),
     "fragment_run_enteries" / PrefixedArray(Int32ub, Struct(
         "first_fragment" / Int32ub,
         "first_fragment_timestamp" / Int64ub,
@@ -212,7 +212,7 @@ HandlerReferenceBox = Struct(
     Padding(4, pattern=b"\x00"),
     "handler_type" / PaddedString(4, "ascii"),
     Padding(12, pattern=b"\x00"),  # Int32ub[3]
-    "name" / CString(encoding="utf8")
+    "name" / CString("utf8")
 )
 
 # Boxes contained by Media Info Box
@@ -235,7 +235,7 @@ DataEntryUrlBox = Prefixed(Int32ub, Struct(
     "flags" / BitStruct(
         Padding(23), "self_contained" / Rebuild(Flag, ~this._.location)
     ),
-    "location" / If(~this.flags.self_contained, CString(encoding="utf8")),
+    "location" / If(~this.flags.self_contained, CString("utf8")),
 ), includelength=True)
 
 DataEntryUrnBox = Prefixed(Int32ub, Struct(
@@ -244,8 +244,8 @@ DataEntryUrnBox = Prefixed(Int32ub, Struct(
     "flags" / BitStruct(
         Padding(23), "self_contained" / Rebuild(Flag, ~(this._.name & this._.location))
     ),
-    "name" / If(this.flags == 0, CString(encoding="utf8")),
-    "location" / If(this.flags == 0, CString(encoding="utf8")),
+    "name" / If(this.flags == 0, CString("utf8")),
+    "location" / If(this.flags == 0, CString("utf8")),
 ), includelength=True)
 
 DataReferenceBox = Struct(
@@ -287,8 +287,8 @@ AAVC = Struct(
         Padding(6, pattern=b'\x01'),
         "nal_unit_length_field" / Default(BitsInteger(2), 3),
     ),
-    "sps" / Default(PrefixedArray(MaskedInteger(Int8ub), PascalString(Int16ub)), []),
-    "pps" / Default(PrefixedArray(Int8ub, PascalString(Int16ub)), [])
+    "sps" / Default(PrefixedArray(MaskedInteger(Int8ub), PascalString(Int16ub, "ascii")), []),
+    "pps" / Default(PrefixedArray(Int8ub, PascalString(Int16ub, "ascii")), [])
 )
 
 HVCC = Struct(
@@ -682,7 +682,7 @@ SchemeTypeBox = Struct(
     "flags" / Default(Int24ub, 0),
     "scheme_type" / Default(PaddedString(4, "ascii"), "cenc"),
     "scheme_version" / Default(Int32ub, 0x00010000),
-    "schema_uri" / Default(If(this.flags & 1 == 1, CString()), None)
+    "schema_uri" / Default(If(this.flags & 1 == 1, CString("ascii")), None)
 )
 
 ProtectionSchemeInformationBox = Struct(

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -108,7 +108,7 @@ HDSSegmentBox = Struct(
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
     "info_version" / Int32ub,
-    EmbeddedBitStruct(
+    "flags" / BitStruct(
         Padding(1),
         "profile" / Flag,
         "live" / Flag,
@@ -166,10 +166,10 @@ MediaHeaderBox = Struct(
     "modification_time" / IfThenElse(this.version == 1, Int64ub, Int32ub),
     "timescale" / Int32ub,
     "duration" / IfThenElse(this.version == 1, Int64ub, Int32ub),
-    Embedded(BitStruct(
+    "flags" / BitStruct(
         Padding(1),
         "language" / ISO6392TLanguageCode(BitsInteger(5)[3]),
-    )),
+    ),
     Padding(2, pattern=b"\x00"),
 )
 
@@ -242,7 +242,7 @@ AAVC = Struct(
     "profile" / Int8ub,
     "compatibility" / Int8ub,
     "level" / Int8ub,
-    EmbeddedBitStruct(
+    "flags" / BitStruct(
         Padding(6, pattern=b'\x01'),
         "nal_unit_length_field" / Default(BitsInteger(2), 3),
     ),
@@ -251,8 +251,8 @@ AAVC = Struct(
 )
 
 HVCC = Struct(
-    EmbeddedBitStruct(
-        "version" / Const(1, BitsInteger(8)),
+    "version" / Const(1, Int8ub),
+    "flags" / BitStruct(
         "profile_space" / BitsInteger(2),
         "general_tier_flag" / BitsInteger(1),
         "general_profile" / BitsInteger(5),

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -21,6 +21,7 @@ from construct import *
 from construct.lib import *
 
 from pymp4.adapters import ISO6392TLanguageCode, MaskedInteger, UUIDBytes
+from pymp4.subconstructs import TellPlusSizeOf
 
 log = logging.getLogger(__name__)
 
@@ -714,7 +715,7 @@ Box = Prefixed(Int32ub, Struct(
         "asrt": HDSSegmentRunBox,
         "afrt": HDSFragmentRunBox
     }, default=RawBox)),
-    "end" / Tell
+    "end" / TellPlusSizeOf(Int32ub)
 ), includelength=True)
 
 ContainerBox = Struct(

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -136,9 +136,9 @@ MovieHeaderBox = Struct(
     "rate" / Default(Int32sb, 65536),
     "volume" / Default(Int16sb, 256),
     # below could be just Padding(10) but why not
-    Const(Int16ub, 0),
-    Const(Int32ub, 0),
-    Const(Int32ub, 0),
+    Const(0, Int16ub),
+    Const(0, Int32ub),
+    Const(0, Int32ub),
     "matrix" / Default(Int32sb[9], UNITY_MATRIX),
     "pre_defined" / Default(Int32ub[6], [0] * 6),
     "next_track_ID" / Default(Int32ub, 0xffffffff)
@@ -248,7 +248,7 @@ class ISO6392TLanguageCode(Adapter):
 MediaHeaderBox = Struct(
     "type" / Const(b"mdhd"),
     "version" / Default(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "creation_time" / IfThenElse(this.version == 1, Int64ub, Int32ub),
     "modification_time" / IfThenElse(this.version == 1, Int64ub, Int32ub),
     "timescale" / Int32ub,
@@ -262,8 +262,8 @@ MediaHeaderBox = Struct(
 
 HandlerReferenceBox = Struct(
     "type" / Const(b"hdlr"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     Padding(4, pattern=b"\x00"),
     "handler_type" / PaddedString(4, "ascii"),
     Padding(12, pattern=b"\x00"),  # Int32ub[3]
@@ -275,7 +275,7 @@ HandlerReferenceBox = Struct(
 VideoMediaHeaderBox = Struct(
     "type" / Const(b"vmhd"),
     "version" / Default(Int8ub, 0),
-    "flags" / Const(Int24ub, 1),
+    "flags" / Const(1, Int24ub),
     "graphics_mode" / Default(Int16ub, 0),
     "opcolor" / Struct(
         "red" / Default(Int16ub, 0),
@@ -286,7 +286,7 @@ VideoMediaHeaderBox = Struct(
 
 DataEntryUrlBox = PrefixedIncludingSize(Int32ub, Struct(
     "type" / Const(b"url "),
-    "version" / Const(Int8ub, 0),
+    "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(23), "self_contained" / Rebuild(Flag, ~this._.location)
     ),
@@ -295,7 +295,7 @@ DataEntryUrlBox = PrefixedIncludingSize(Int32ub, Struct(
 
 DataEntryUrnBox = PrefixedIncludingSize(Int32ub, Struct(
     "type" / Const(b"urn "),
-    "version" / Const(Int8ub, 0),
+    "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(23), "self_contained" / Rebuild(Flag, ~(this._.name & this._.location))
     ),
@@ -305,7 +305,7 @@ DataEntryUrnBox = PrefixedIncludingSize(Int32ub, Struct(
 
 DataReferenceBox = Struct(
     "type" / Const(b"dref"),
-    "version" / Const(Int8ub, 0),
+    "version" / Const(0, Int8ub),
     "flags" / Default(Int24ub, 0),
     "data_entries" / PrefixedArray(Int32ub, Select(DataEntryUrnBox, DataEntryUrlBox)),
 )
@@ -314,12 +314,12 @@ DataReferenceBox = Struct(
 
 MP4ASampleEntryBox = Struct(
     "version" / Default(Int16ub, 0),
-    "revision" / Const(Int16ub, 0),
-    "vendor" / Const(Int32ub, 0),
+    "revision" / Const(0, Int16ub),
+    "vendor" / Const(0, Int32ub),
     "channels" / Default(Int16ub, 2),
     "bits_per_sample" / Default(Int16ub, 16),
     "compression_id" / Default(Int16sb, 0),
-    "packet_size" / Const(Int16ub, 0),
+    "packet_size" / Const(0, Int16ub),
     "sampling_rate" / Int16ub,
     Padding(2)
 )
@@ -334,7 +334,7 @@ class MaskedInteger(Adapter):
 
 
 AAVC = Struct(
-    "version" / Const(Int8ub, 1),
+    "version" / Const(1, Int8ub),
     "profile" / Int8ub,
     "compatibility" / Int8ub,
     "level" / Int8ub,
@@ -348,7 +348,7 @@ AAVC = Struct(
 
 HVCC = Struct(
     EmbeddedBitStruct(
-        "version" / Const(BitsInteger(8), 1),
+        "version" / Const(1, BitsInteger(8)),
         "profile_space" / BitsInteger(2),
         "general_tier_flag" / BitsInteger(1),
         "general_profile" / BitsInteger(5),
@@ -377,7 +377,7 @@ HVCC = Struct(
 
 AVC1SampleEntryBox = Struct(
     "version" / Default(Int16ub, 0),
-    "revision" / Const(Int16ub, 0),
+    "revision" / Const(0, Int16ub),
     "vendor" / Default(PaddedString(4, "ascii"), "brdy"),
     "temporal_quality" / Default(Int32ub, 0),
     "spatial_quality" / Default(Int32ub, 0),
@@ -387,7 +387,7 @@ AVC1SampleEntryBox = Struct(
     Padding(2),
     "vertical_resolution" / Default(Int16ub, 72),  # TODO: actually a fixed point decimal
     Padding(2),
-    "data_size" / Const(Int32ub, 0),
+    "data_size" / Const(0, Int32ub),
     "frame_count" / Default(Int16ub, 1),
     "compressor_name" / Default(PaddedString(32, "ascii"), None),
     "depth" / Default(Int16ub, 24),
@@ -425,14 +425,14 @@ BitRateBox = Struct(
 SampleDescriptionBox = Struct(
     "type" / Const(b"stsd"),
     "version" / Default(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "entries" / PrefixedArray(Int32ub, SampleEntryBox)
 )
 
 SampleSizeBox = Struct(
     "type" / Const(b"stsz"),
     "version" / Int8ub,
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "sample_size" / Int32ub,
     "sample_count" / Int32ub,
     "entry_sizes" / If(this.sample_size == 0, Array(this.sample_count, Int32ub))
@@ -441,7 +441,7 @@ SampleSizeBox = Struct(
 SampleSizeBox2 = Struct(
     "type" / Const(b"stz2"),
     "version" / Int8ub,
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     Padding(3, pattern=b"\x00"),
     "field_size" / Int8ub,
     "sample_count" / Int24ub,
@@ -452,14 +452,14 @@ SampleSizeBox2 = Struct(
 
 SampleDegradationPriorityBox = Struct(
     "type" / Const(b"stdp"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
 )
 
 TimeToSampleBox = Struct(
     "type" / Const(b"stts"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
         "sample_count" / Int32ub,
         "sample_delta" / Int32ub,
@@ -468,8 +468,8 @@ TimeToSampleBox = Struct(
 
 SyncSampleBox = Struct(
     "type" / Const(b"stss"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
         "sample_number" / Int32ub,
     )), [])
@@ -477,8 +477,8 @@ SyncSampleBox = Struct(
 
 SampleToChunkBox = Struct(
     "type" / Const(b"stsc"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
         "first_chunk" / Int32ub,
         "samples_per_chunk" / Int32ub,
@@ -488,8 +488,8 @@ SampleToChunkBox = Struct(
 
 ChunkOffsetBox = Struct(
     "type" / Const(b"stco"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
         "chunk_offset" / Int32ub,
     )), [])
@@ -497,8 +497,8 @@ ChunkOffsetBox = Struct(
 
 ChunkLargeOffsetBox = Struct(
     "type" / Const(b"co64"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "entries" / PrefixedArray(Int32ub, Struct(
         "chunk_offset" / Int64ub,
     ))
@@ -508,15 +508,15 @@ ChunkLargeOffsetBox = Struct(
 
 MovieFragmentHeaderBox = Struct(
     "type" / Const(b"mfhd"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "sequence_number" / Int32ub
 )
 
 TrackFragmentBaseMediaDecodeTimeBox = Struct(
     "type" / Const(b"tfdt"),
     "version" / Int8ub,
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "baseMediaDecodeTime" / Switch(this.version, {1: Int64ub, 0: Int32ub})
 )
 
@@ -585,7 +585,7 @@ TrackFragmentHeaderBox = Struct(
 MovieExtendsHeaderBox = Struct(
     "type" / Const(b"mehd"),
     "version" / Default(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "fragment_duration" / IfThenElse(this.version == 1,
                                      Default(Int64ub, 0),
                                      Default(Int32ub, 0))
@@ -593,8 +593,8 @@ MovieExtendsHeaderBox = Struct(
 
 TrackExtendsBox = Struct(
     "type" / Const(b"trex"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "track_ID" / Int32ub,
     "default_sample_description_index" / Default(Int32ub, 1),
     "default_sample_duration" / Default(Int32ub, 0),
@@ -605,7 +605,7 @@ TrackExtendsBox = Struct(
 SegmentIndexBox = Struct(
     "type" / Const(b"sidx"),
     "version" / Int8ub,
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "reference_ID" / Int32ub,
     "timescale" / Int32ub,
     "earliest_presentation_time" / IfThenElse(this.version == 0, Int32ub, Int64ub),
@@ -624,7 +624,7 @@ SegmentIndexBox = Struct(
 
 SampleAuxiliaryInformationSizesBox = Struct(
     "type" / Const(b"saiz"),
-    "version" / Const(Int8ub, 0),
+    "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(23),
         "has_aux_info_type" / Flag,
@@ -664,10 +664,10 @@ MovieDataBox = Struct(
 
 SoundMediaHeaderBox = Struct(
     "type" / Const(b"smhd"),
-    "version" / Const(Int8ub, 0),
-    "flags" / Const(Int24ub, 0),
+    "version" / Const(0, Int8ub),
+    "flags" / Const(0, Int24ub),
     "balance" / Default(Int16sb, 0),
-    "reserved" / Const(Int16ub, 0)
+    "reserved" / Const(0, Int16ub)
 )
 
 
@@ -684,7 +684,7 @@ class UUIDBytes(Adapter):
 ProtectionSystemHeaderBox = Struct(
     "type" / If(this._.type != "uuid", Const(b"pssh")),
     "version" / Rebuild(Int8ub, lambda ctx: 1 if (hasattr(ctx, "key_IDs") and ctx.key_IDs) else 0),
-    "flags" / Const(Int24ub, 0),
+    "flags" / Const(0, Int24ub),
     "system_ID" / UUIDBytes(Bytes(16)),
     "key_IDs" / Default(If(this.version == 1,
                            PrefixedArray(Int32ub, UUIDBytes(Bytes(16)))),
@@ -696,8 +696,8 @@ TrackEncryptionBox = Struct(
     "type" / If(this._.type != "uuid", Const(b"tenc")),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
-    "_reserved0" / Const(Int8ub, 0),
-    "_reserved1" / Const(Int8ub, 0),
+    "_reserved0" / Const(0, Int8ub),
+    "_reserved1" / Const(0, Int8ub),
     "is_encrypted" / Int8ub,
     "iv_size" / Int8ub,
     "key_ID" / UUIDBytes(Bytes(16)),
@@ -710,7 +710,7 @@ TrackEncryptionBox = Struct(
 
 SampleEncryptionBox = Struct(
     "type" / If(this._.type != "uuid", Const(b"senc")),
-    "version" / Const(Int8ub, 0),
+    "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(22),
         "has_subsample_encryption_info" / Flag,

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -31,14 +31,12 @@ UNITY_MATRIX = [0x10000, 0, 0, 0, 0x10000, 0, 0, 0, 0x40000000]
 # Header box
 
 FileTypeBox = Struct(
-    "type" / Const(b"ftyp"),
     "major_brand" / PaddedString(4, "ascii"),
     "minor_version" / Int32ub,
     "compatible_brands" / GreedyRange(PaddedString(4, "ascii")),
 )
 
 SegmentTypeBox = Struct(
-    "type" / Const(b"styp"),
     "major_brand" / PaddedString(4, "ascii"),
     "minor_version" / Int32ub,
     "compatible_brands" / GreedyRange(PaddedString(4, "ascii")),
@@ -52,19 +50,16 @@ RawBox = Struct(
 )
 
 FreeBox = Struct(
-    "type" / Const(b"free"),
     "data" / GreedyBytes
 )
 
 SkipBox = Struct(
-    "type" / Const(b"skip"),
     "data" / GreedyBytes
 )
 
 # Movie boxes, contained in a moov Box
 
 MovieHeaderBox = Struct(
-    "type" / Const(b"mvhd"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
     "creation_time" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
@@ -85,7 +80,6 @@ MovieHeaderBox = Struct(
 # Track boxes, contained in trak box
 
 TrackHeaderBox = Struct(
-    "type" / Const(b"tkhd"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 1),
     "creation_time" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
@@ -104,7 +98,6 @@ TrackHeaderBox = Struct(
 )
 
 HDSSegmentBox = Struct(
-    "type" / Const(b"abst"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
     "info_version" / Int32ub,
@@ -128,7 +121,6 @@ HDSSegmentBox = Struct(
 )
 
 HDSSegmentRunBox = Struct(
-    "type" / Const(b"asrt"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
     "quality_entry_table" / PrefixedArray(Int8ub, CString("ascii")),
@@ -139,7 +131,6 @@ HDSSegmentRunBox = Struct(
 )
 
 HDSFragmentRunBox = Struct(
-    "type" / Const(b"afrt"),
     "version" / Default(Int8ub, 0),
     "flags" / BitStruct(
         Padding(23),
@@ -159,7 +150,6 @@ HDSFragmentRunBox = Struct(
 # Boxes contained by Media Box
 
 MediaHeaderBox = Struct(
-    "type" / Const(b"mdhd"),
     "version" / Default(Int8ub, 0),
     "flags" / Const(0, Int24ub),
     "creation_time" / IfThenElse(this.version == 1, Int64ub, Int32ub),
@@ -171,7 +161,6 @@ MediaHeaderBox = Struct(
 )
 
 HandlerReferenceBox = Struct(
-    "type" / Const(b"hdlr"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     Padding(4, pattern=b"\x00"),
@@ -183,7 +172,6 @@ HandlerReferenceBox = Struct(
 # Boxes contained by Media Info Box
 
 VideoMediaHeaderBox = Struct(
-    "type" / Const(b"vmhd"),
     "version" / Default(Int8ub, 0),
     "flags" / Const(1, Int24ub),
     "graphics_mode" / Default(Int16ub, 0),
@@ -195,7 +183,6 @@ VideoMediaHeaderBox = Struct(
 )
 
 DataEntryUrlBox = Prefixed(Int32ub, Struct(
-    "type" / Const(b"url "),
     "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(23), "self_contained" / Rebuild(Flag, ~this._.location)
@@ -204,7 +191,6 @@ DataEntryUrlBox = Prefixed(Int32ub, Struct(
 ), includelength=True)
 
 DataEntryUrnBox = Prefixed(Int32ub, Struct(
-    "type" / Const(b"urn "),
     "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(23), "self_contained" / Rebuild(Flag, ~(this._.name & this._.location))
@@ -214,7 +200,6 @@ DataEntryUrnBox = Prefixed(Int32ub, Struct(
 ), includelength=True)
 
 DataReferenceBox = Struct(
-    "type" / Const(b"dref"),
     "version" / Const(0, Int8ub),
     "flags" / Default(Int24ub, 0),
     "data_entries" / PrefixedArray(Int32ub, Select(DataEntryUrnBox, DataEntryUrlBox)),
@@ -317,21 +302,18 @@ SampleEntryBox = Prefixed(Int32ub, Struct(
 ), includelength=True)
 
 BitRateBox = Struct(
-    "type" / Const(b"btrt"),
     "bufferSizeDB" / Int32ub,
     "maxBitrate" / Int32ub,
     "avgBirate" / Int32ub,
 )
 
 SampleDescriptionBox = Struct(
-    "type" / Const(b"stsd"),
     "version" / Default(Int8ub, 0),
     "flags" / Const(0, Int24ub),
     "entries" / PrefixedArray(Int32ub, SampleEntryBox)
 )
 
 SampleSizeBox = Struct(
-    "type" / Const(b"stsz"),
     "version" / Int8ub,
     "flags" / Const(0, Int24ub),
     "sample_size" / Int32ub,
@@ -340,7 +322,6 @@ SampleSizeBox = Struct(
 )
 
 SampleSizeBox2 = Struct(
-    "type" / Const(b"stz2"),
     "version" / Int8ub,
     "flags" / Const(0, Int24ub),
     Padding(3, pattern=b"\x00"),
@@ -352,13 +333,11 @@ SampleSizeBox2 = Struct(
 )
 
 SampleDegradationPriorityBox = Struct(
-    "type" / Const(b"stdp"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
 )
 
 TimeToSampleBox = Struct(
-    "type" / Const(b"stts"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
@@ -368,7 +347,6 @@ TimeToSampleBox = Struct(
 )
 
 SyncSampleBox = Struct(
-    "type" / Const(b"stss"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
@@ -377,7 +355,6 @@ SyncSampleBox = Struct(
 )
 
 SampleToChunkBox = Struct(
-    "type" / Const(b"stsc"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
@@ -388,7 +365,6 @@ SampleToChunkBox = Struct(
 )
 
 ChunkOffsetBox = Struct(
-    "type" / Const(b"stco"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "entries" / Default(PrefixedArray(Int32ub, Struct(
@@ -397,7 +373,6 @@ ChunkOffsetBox = Struct(
 )
 
 ChunkLargeOffsetBox = Struct(
-    "type" / Const(b"co64"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "entries" / PrefixedArray(Int32ub, Struct(
@@ -408,14 +383,12 @@ ChunkLargeOffsetBox = Struct(
 # Movie Fragment boxes, contained in moof box
 
 MovieFragmentHeaderBox = Struct(
-    "type" / Const(b"mfhd"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "sequence_number" / Int32ub
 )
 
 TrackFragmentBaseMediaDecodeTimeBox = Struct(
-    "type" / Const(b"tfdt"),
     "version" / Int8ub,
     "flags" / Const(0, Int24ub),
     "baseMediaDecodeTime" / Switch(this.version, {1: Int64ub, 0: Int32ub})
@@ -433,7 +406,6 @@ TrackSampleFlags = BitStruct(
 )
 
 TrackRunBox = Struct(
-    "type" / Const(b"trun"),
     "version" / Int8ub,
     "flags" / BitStruct(
         Padding(12),
@@ -461,7 +433,6 @@ TrackRunBox = Struct(
 )
 
 TrackFragmentHeaderBox = Struct(
-    "type" / Const(b"tfhd"),
     "version" / Int8ub,
     "flags" / BitStruct(
         Padding(6),
@@ -484,7 +455,6 @@ TrackFragmentHeaderBox = Struct(
 )
 
 MovieExtendsHeaderBox = Struct(
-    "type" / Const(b"mehd"),
     "version" / Default(Int8ub, 0),
     "flags" / Const(0, Int24ub),
     "fragment_duration" / IfThenElse(this.version == 1,
@@ -493,7 +463,6 @@ MovieExtendsHeaderBox = Struct(
 )
 
 TrackExtendsBox = Struct(
-    "type" / Const(b"trex"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "track_ID" / Int32ub,
@@ -504,7 +473,6 @@ TrackExtendsBox = Struct(
 )
 
 SegmentIndexBox = Struct(
-    "type" / Const(b"sidx"),
     "version" / Int8ub,
     "flags" / Const(0, Int24ub),
     "reference_ID" / Int32ub,
@@ -524,7 +492,6 @@ SegmentIndexBox = Struct(
 )
 
 SampleAuxiliaryInformationSizesBox = Struct(
-    "type" / Const(b"saiz"),
     "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(23),
@@ -541,7 +508,6 @@ SampleAuxiliaryInformationSizesBox = Struct(
 )
 
 SampleAuxiliaryInformationOffsetsBox = Struct(
-    "type" / Const(b"saio"),
     "version" / Int8ub,
     "flags" / BitStruct(
         Padding(23),
@@ -557,14 +523,12 @@ SampleAuxiliaryInformationOffsetsBox = Struct(
 # Movie data box
 
 MovieDataBox = Struct(
-    "type" / Const(b"mdat"),
     "data" / GreedyBytes
 )
 
 # Media Info Box
 
 SoundMediaHeaderBox = Struct(
-    "type" / Const(b"smhd"),
     "version" / Const(0, Int8ub),
     "flags" / Const(0, Int24ub),
     "balance" / Default(Int16sb, 0),
@@ -575,7 +539,6 @@ SoundMediaHeaderBox = Struct(
 # DASH Boxes
 
 ProtectionSystemHeaderBox = Struct(
-    "type" / If(this._.type != "uuid", Const(b"pssh")),
     "version" / Rebuild(Int8ub, lambda ctx: 1 if (hasattr(ctx, "key_IDs") and ctx.key_IDs) else 0),
     "flags" / Const(0, Int24ub),
     "system_ID" / UUIDBytes(Bytes(16)),
@@ -586,7 +549,6 @@ ProtectionSystemHeaderBox = Struct(
 )
 
 TrackEncryptionBox = Struct(
-    "type" / If(this._.type != "uuid", Const(b"tenc")),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
     "_reserved0" / Const(0, Int8ub),
@@ -602,7 +564,6 @@ TrackEncryptionBox = Struct(
 )
 
 SampleEncryptionBox = Struct(
-    "type" / If(this._.type != "uuid", Const(b"senc")),
     "version" / Const(0, Int8ub),
     "flags" / BitStruct(
         Padding(22),
@@ -620,12 +581,10 @@ SampleEncryptionBox = Struct(
 )
 
 OriginalFormatBox = Struct(
-    "type" / Const(b"frma"),
     "original_format" / Default(PaddedString(4, "ascii"), "avc1")
 )
 
 SchemeTypeBox = Struct(
-    "type" / Const(b"schm"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
     "scheme_type" / Default(PaddedString(4, "ascii"), "cenc"),
@@ -634,7 +593,6 @@ SchemeTypeBox = Struct(
 )
 
 ProtectionSchemeInformationBox = Struct(
-    "type" / Const(b"sinf"),
     # TODO: define which children are required 'schm', 'schi' and 'tenc'
     "children" / LazyBound(lambda _: GreedyRange(Box))
 )
@@ -642,7 +600,6 @@ ProtectionSchemeInformationBox = Struct(
 # PIFF boxes
 
 UUIDBox = Struct(
-    "type" / Const(b"uuid"),
     "extended_type" / UUIDBytes(Bytes(16)),
     "data" / Switch(this.extended_type, {
         UUID("A2394F52-5A9B-4F14-A244-6C427C648DF4"): SampleEncryptionBox,
@@ -656,7 +613,7 @@ ContainerBoxLazy = LazyBound(lambda: ContainerBox)
 
 Box = Prefixed(Int32ub, Struct(
     "offset" / Tell,
-    "type" / Peek(PaddedString(4, "ascii")),
+    "type" / PaddedString(4, "ascii"),
     Embedded(Switch(this.type, {
         "ftyp": FileTypeBox,
         "styp": SegmentTypeBox,
@@ -716,7 +673,6 @@ Box = Prefixed(Int32ub, Struct(
 ), includelength=True)
 
 ContainerBox = Struct(
-    "type" / PaddedString(4, "ascii"),
     "children" / GreedyRange(Box)
 )
 

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -166,11 +166,8 @@ MediaHeaderBox = Struct(
     "modification_time" / IfThenElse(this.version == 1, Int64ub, Int32ub),
     "timescale" / Int32ub,
     "duration" / IfThenElse(this.version == 1, Int64ub, Int32ub),
-    "flags" / BitStruct(
-        Padding(1),
-        "language" / ISO6392TLanguageCode(BitsInteger(5)[3]),
-    ),
-    Padding(2, pattern=b"\x00"),
+    "language" / ISO6392TLanguageCode(Int16ub),
+    Padding(2, pattern=b"\x00")
 )
 
 HandlerReferenceBox = Struct(

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -280,10 +280,10 @@ AVC1SampleEntryBox = Struct(
     "color_table_id" / Default(Int16sb, -1),
     "avc_data" / Prefixed(Int32ub, Struct(
         "type" / PaddedString(4, "ascii"),
-        Embedded(Switch(this.type, {
+        "data" / Switch(this.type, {
             "avcC": AAVC,
             "hvcC": HVCC,
-        }, Struct("data" / GreedyBytes)))
+        }, GreedyBytes)
     ), includelength=True),
     "sample_info" / LazyBound(lambda _: GreedyRange(Box))
 )
@@ -292,13 +292,13 @@ SampleEntryBox = Prefixed(Int32ub, Struct(
     "format" / PaddedString(4, "ascii"),
     Padding(6, pattern=b"\x00"),
     "data_reference_index" / Default(Int16ub, 1),
-    Embedded(Switch(this.format, {
+    "data" / Switch(this.format, {
         "ec-3": MP4ASampleEntryBox,
         "mp4a": MP4ASampleEntryBox,
         "enca": MP4ASampleEntryBox,
         "avc1": AVC1SampleEntryBox,
         "encv": AVC1SampleEntryBox
-    }, Struct("data" / GreedyBytes)))
+    }, GreedyBytes)
 ), includelength=True)
 
 BitRateBox = Struct(
@@ -614,7 +614,7 @@ ContainerBoxLazy = LazyBound(lambda: ContainerBox)
 Box = Prefixed(Int32ub, Struct(
     "offset" / Tell,
     "type" / PaddedString(4, "ascii"),
-    Embedded(Switch(this.type, {
+    "data" / Switch(this.type, {
         "ftyp": FileTypeBox,
         "styp": SegmentTypeBox,
         "mvhd": MovieHeaderBox,
@@ -668,7 +668,7 @@ Box = Prefixed(Int32ub, Struct(
         "abst": HDSSegmentBox,
         "asrt": HDSSegmentRunBox,
         "afrt": HDSFragmentRunBox
-    }, default=RawBox)),
+    }, default=RawBox),
     "end" / TellPlusSizeOf(Int32ub)
 ), includelength=True)
 

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -66,20 +66,10 @@ MovieHeaderBox = Struct(
     "type" / Const(b"mvhd"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 0),
-    Embedded(Switch(this.version, {
-        1: Struct(
-            "creation_time" / Default(Int64ub, 0),
-            "modification_time" / Default(Int64ub, 0),
-            "timescale" / Default(Int32ub, 10000000),
-            "duration" / Int64ub
-        ),
-        0: Struct(
-            "creation_time" / Default(Int32ub, 0),
-            "modification_time" / Default(Int32ub, 0),
-            "timescale" / Default(Int32ub, 10000000),
-            "duration" / Int32ub,
-        ),
-    })),
+    "creation_time" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
+    "modification_time" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
+    "timescale" / Default(Int32ub, 10000000),
+    "duration" / Switch(this.version, {0: Int32ub, 1: Int64ub}),
     "rate" / Default(Int32sb, 65536),
     "volume" / Default(Int16sb, 256),
     # below could be just Padding(10) but why not
@@ -97,22 +87,11 @@ TrackHeaderBox = Struct(
     "type" / Const(b"tkhd"),
     "version" / Default(Int8ub, 0),
     "flags" / Default(Int24ub, 1),
-    Embedded(Switch(this.version, {
-        1: Struct(
-            "creation_time" / Default(Int64ub, 0),
-            "modification_time" / Default(Int64ub, 0),
-            "track_ID" / Default(Int32ub, 1),
-            Padding(4),
-            "duration" / Default(Int64ub, 0),
-        ),
-        0: Struct(
-            "creation_time" / Default(Int32ub, 0),
-            "modification_time" / Default(Int32ub, 0),
-            "track_ID" / Default(Int32ub, 1),
-            Padding(4),
-            "duration" / Default(Int32ub, 0),
-        ),
-    })),
+    "creation_time" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
+    "modification_time" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
+    "track_ID" / Default(Int32ub, 1),
+    Padding(4),
+    "duration" / Default(Switch(this.version, {0: Int32ub, 1: Int64ub}), 0),
     Padding(8),
     "layer" / Default(Int16sb, 0),
     "alternate_group" / Default(Int16sb, 0),

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -298,7 +298,7 @@ SampleEntryBox = Prefixed(Int32ub, Struct(
         "enca": MP4ASampleEntryBox,
         "avc1": AVC1SampleEntryBox,
         "encv": AVC1SampleEntryBox,
-        "wvtt": Struct("children" / LazyBound(lambda ctx: GreedyRange(Box)))
+        "wvtt": Struct("children" / LazyBound(lambda: GreedyRange(Box)))
     }, GreedyBytes)
 ), includelength=True)
 
@@ -552,7 +552,7 @@ ProtectionSystemHeaderBox = Struct(
 TrackEncryptionBox = Struct(
     "version" / Default(OneOf(Int8ub, (0, 1)), 0),
     "flags" / Default(Int24ub, 0),
-    "_reserved" / Const(Int8ub, 0),
+    "_reserved" / Const(0, Int8ub),
     "default_byte_blocks" / Default(IfThenElse(
         this.version > 0,
         BitStruct(
@@ -561,7 +561,7 @@ TrackEncryptionBox = Struct(
             # count of unencrypted blocks in the protection pattern
             "skip" / Nibble
         ),
-        Const(Int8ub, 0)
+        Const(0, Int8ub)
     ), 0),
     "is_encrypted" / OneOf(Int8ub, (0, 1)),
     "iv_size" / OneOf(Int8ub, (0, 8, 16)),
@@ -620,46 +620,26 @@ UUIDBox = Struct(
 # WebVTT boxes
 
 CueIDBox = Struct(
-    "type" / Const(b"iden"),
     "cue_id" / GreedyString("utf8")
 )
 
 CueSettingsBox = Struct(
-    "type" / Const(b"sttg"),
     "settings" / GreedyString("utf8")
 )
 
 CuePayloadBox = Struct(
-    "type" / Const(b"payl"),
     "cue_text" / GreedyString("utf8")
 )
 
 WebVTTConfigurationBox = Struct(
-    "type" / Const(b"vttC"),
     "config" / GreedyString("utf8")
 )
 
 WebVTTSourceLabelBox = Struct(
-    "type" / Const(b"vlab"),
     "label" / GreedyString("utf8")
 )
 
-ContainerBoxLazy = LazyBound(lambda ctx: ContainerBox)
-
-
-class TellMinusSizeOf(Subconstruct):
-    def __init__(self, subcon):
-        super(TellMinusSizeOf, self).__init__(subcon)
-        self.flagbuildnone = True
-
-    def _parse(self, stream, context, path):
-        return stream.tell() - self.subcon.sizeof(context)
-
-    def _build(self, obj, stream, context, path):
-        return b""
-
-    def sizeof(self, context=None, **kw):
-        return 0
+ContainerBoxLazy = LazyBound(lambda: ContainerBox)
 
 
 Box = Prefixed(Int32ub, Struct(

--- a/src/pymp4/subconstructs.py
+++ b/src/pymp4/subconstructs.py
@@ -1,0 +1,18 @@
+from abc import ABC
+
+from construct import Subconstruct
+
+
+class TellPlusSizeOf(Subconstruct, ABC):
+    def __init__(self, subcon):
+        super(TellPlusSizeOf, self).__init__(subcon)
+        self.flagbuildnone = True
+
+    def _parse(self, stream, context, path):
+        return stream.tell() + self.subcon.sizeof(context=context)
+
+    def _build(self, obj, stream, context, path):
+        return b""
+
+    def sizeof(self, context=None, **kw):
+        return 0

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -28,20 +28,20 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1'),
             Container(offset=0)
-            (type=b"ftyp")
-            (major_brand=b"iso5")
+            (type="ftyp")
+            (major_brand="iso5")
             (minor_version=1)
-            (compatible_brands=[b"iso5", b"avc1"])
+            (compatible_brands=["iso5", "avc1"])
             (end=24)
         )
 
     def test_ftyp_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"ftyp",
-                major_brand=b"iso5",
+                type="ftyp",
+                major_brand="iso5",
                 minor_version=1,
-                compatible_brands=[b"iso5", b"avc1"])),
+                compatible_brands=["iso5", "avc1"])),
             b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1')
 
     def test_mdhd_parse(self):
@@ -49,7 +49,7 @@ class BoxTests(unittest.TestCase):
             Box.parse(
                 b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00'),
             Container(offset=0)
-            (type=b"mdhd")(version=0)(flags=0)
+            (type="mdhd")(version=0)(flags=0)
             (creation_time=0)
             (modification_time=0)
             (timescale=1000000)
@@ -60,7 +60,7 @@ class BoxTests(unittest.TestCase):
 
     def test_mdhd_build(self):
         mdhd_data = Box.build(dict(
-            type=b"mdhd",
+            type="mdhd",
             creation_time=0,
             modification_time=0,
             timescale=1000000,
@@ -71,7 +71,7 @@ class BoxTests(unittest.TestCase):
                          b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00')
 
         mdhd_data64 = Box.build(dict(
-            type=b"mdhd",
+            type="mdhd",
             version=1,
             creation_time=0,
             modification_time=0,
@@ -84,11 +84,11 @@ class BoxTests(unittest.TestCase):
 
     def test_moov_build(self):
         moov = \
-            Container(type=b"moov")(children=[  # 96 bytes
-                Container(type=b"mvex")(children=[  # 88 bytes
-                    Container(type=b"mehd")(version=0)(flags=0)(fragment_duration=0),  # 16 bytes
-                    Container(type=b"trex")(track_ID=1),  # 32 bytes
-                    Container(type=b"trex")(track_ID=2),  # 32 bytes
+            Container(type="moov")(children=[  # 96 bytes
+                Container(type="mvex")(children=[  # 88 bytes
+                    Container(type="mehd")(version=0)(flags=0)(fragment_duration=0),  # 16 bytes
+                    Container(type="trex")(track_ID=1),  # 32 bytes
+                    Container(type="trex")(track_ID=2),  # 32 bytes
                 ])
             ])
 
@@ -109,13 +109,13 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(in_bytes + b'padding'),
             Container(offset=0)
-            (type=b"smhd")(version=0)(flags=0)
+            (type="smhd")(version=0)(flags=0)
             (balance=0)(reserved=0)(end=len(in_bytes))
         )
 
     def test_smhd_build(self):
         smhd_data = Box.build(dict(
-            type=b"smhd",
+            type="smhd",
             balance=0))
         self.assertEqual(len(smhd_data), 16),
         self.assertEqual(smhd_data, b'\x00\x00\x00\x10smhd\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -126,7 +126,7 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(in_bytes + b'padding'),
             Container(offset=0)
-            (type=b"stsd")(version=0)(flags=0)
-            (entries=[Container(format=b'tx3g')(data_reference_index=1)(data=tx3g_data)])
+            (type="stsd")(version=0)(flags=0)
+            (entries=[Container(format="tx3g")(data_reference_index=1)(data=tx3g_data)])
             (end=len(in_bytes))
         )

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -27,12 +27,14 @@ class BoxTests(unittest.TestCase):
     def test_ftyp_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1'),
-            Container(offset=0)
-            (type="ftyp")
-            (major_brand="iso5")
-            (minor_version=1)
-            (compatible_brands=["iso5", "avc1"])
-            (end=24)
+            Container(
+                offset=0,
+                type="ftyp",
+                major_brand="iso5",
+                minor_version=1,
+                compatible_brands=["iso5", "avc1"],
+                end=24
+            )
         )
 
     def test_ftyp_build(self):
@@ -46,16 +48,19 @@ class BoxTests(unittest.TestCase):
 
     def test_mdhd_parse(self):
         self.assertEqual(
-            Box.parse(
-                b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00'),
-            Container(offset=0)
-            (type="mdhd")(version=0)(flags=0)
-            (creation_time=0)
-            (modification_time=0)
-            (timescale=1000000)
-            (duration=0)
-            (language="und")
-            (end=32)
+            Box.parse(b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00'),
+            Container(
+                offset=0,
+                type="mdhd",
+                version=0,
+                flags=0,
+                creation_time=0,
+                modification_time=0,
+                timescale=1000000,
+                duration=0,
+                language="und",
+                end=32
+            )
         )
 
     def test_mdhd_build(self):
@@ -84,11 +89,11 @@ class BoxTests(unittest.TestCase):
 
     def test_moov_build(self):
         moov = \
-            Container(type="moov")(children=[  # 96 bytes
-                Container(type="mvex")(children=[  # 88 bytes
-                    Container(type="mehd")(version=0)(flags=0)(fragment_duration=0),  # 16 bytes
-                    Container(type="trex")(track_ID=1),  # 32 bytes
-                    Container(type="trex")(track_ID=2),  # 32 bytes
+            Container(type="moov", children=[  # 96 bytes
+                Container(type="mvex", children=[  # 88 bytes
+                    Container(type="mehd", version=0, flags=0, fragment_duration=0),  # 16 bytes
+                    Container(type="trex", track_ID=1),  # 32 bytes
+                    Container(type="trex", track_ID=2),  # 32 bytes
                 ])
             ])
 
@@ -108,9 +113,15 @@ class BoxTests(unittest.TestCase):
         in_bytes = b'\x00\x00\x00\x10smhd\x00\x00\x00\x00\x00\x00\x00\x00'
         self.assertEqual(
             Box.parse(in_bytes + b'padding'),
-            Container(offset=0)
-            (type="smhd")(version=0)(flags=0)
-            (balance=0)(reserved=0)(end=len(in_bytes))
+            Container(
+                offset=0,
+                type="smhd",
+                version=0,
+                flags=0,
+                balance=0,
+                reserved=0,
+                end=len(in_bytes)
+            )
         )
 
     def test_smhd_build(self):
@@ -125,8 +136,14 @@ class BoxTests(unittest.TestCase):
         in_bytes = b'\x00\x00\x00\x50stsd\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x40tx3g\x00\x00\x00\x00\x00\x00\x00\x01' + tx3g_data
         self.assertEqual(
             Box.parse(in_bytes + b'padding'),
-            Container(offset=0)
-            (type="stsd")(version=0)(flags=0)
-            (entries=[Container(format="tx3g")(data_reference_index=1)(data=tx3g_data)])
-            (end=len(in_bytes))
+            Container(
+                offset=0,
+                type="stsd",
+                version=0,
+                flags=0,
+                entries=[
+                    Container(format='tx3g', data_reference_index=1, data=tx3g_data)
+                ],
+                end=len(in_bytes)
+            )
         )

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -30,9 +30,11 @@ class BoxTests(unittest.TestCase):
             Container(
                 offset=0,
                 type="ftyp",
-                major_brand="iso5",
-                minor_version=1,
-                compatible_brands=["iso5", "avc1"],
+                data=Container(
+                    major_brand="iso5",
+                    minor_version=1,
+                    compatible_brands=["iso5", "avc1"]
+                ),
                 end=24
             )
         )
@@ -41,9 +43,12 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.build(dict(
                 type="ftyp",
-                major_brand="iso5",
-                minor_version=1,
-                compatible_brands=["iso5", "avc1"])),
+                data=dict(
+                    major_brand="iso5",
+                    minor_version=1,
+                    compatible_brands=["iso5", "avc1"]
+                )
+            )),
             b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1')
 
     def test_mdhd_parse(self):
@@ -52,13 +57,15 @@ class BoxTests(unittest.TestCase):
             Container(
                 offset=0,
                 type="mdhd",
-                version=0,
-                flags=0,
-                creation_time=0,
-                modification_time=0,
-                timescale=1000000,
-                duration=0,
-                language="und",
+                data=Container(
+                    version=0,
+                    flags=0,
+                    creation_time=0,
+                    modification_time=0,
+                    timescale=1000000,
+                    duration=0,
+                    language="und"
+                ),
                 end=32
             )
         )
@@ -66,36 +73,40 @@ class BoxTests(unittest.TestCase):
     def test_mdhd_build(self):
         mdhd_data = Box.build(dict(
             type="mdhd",
-            creation_time=0,
-            modification_time=0,
-            timescale=1000000,
-            duration=0,
-            language=u"und"))
+            data=dict(
+                creation_time=0,
+                modification_time=0,
+                timescale=1000000,
+                duration=0,
+                language="und"
+            )))
         self.assertEqual(len(mdhd_data), 32)
         self.assertEqual(mdhd_data,
                          b'\x00\x00\x00\x20mdhd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00U\xc4\x00\x00')
 
         mdhd_data64 = Box.build(dict(
             type="mdhd",
-            version=1,
-            creation_time=0,
-            modification_time=0,
-            timescale=1000000,
-            duration=0,
-            language=u"und"))
+            data=dict(
+                version=1,
+                creation_time=0,
+                modification_time=0,
+                timescale=1000000,
+                duration=0,
+                language="und"
+            )))
         self.assertEqual(len(mdhd_data64), 44)
         self.assertEqual(mdhd_data64,
                          b'\x00\x00\x00,mdhd\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fB@\x00\x00\x00\x00\x00\x00\x00\x00U\xc4\x00\x00')
 
     def test_moov_build(self):
         moov = \
-            Container(type="moov", children=ListContainer([  # 96 bytes
-                Container(type="mvex", children=ListContainer([  # 88 bytes
-                    Container(type="mehd", version=0, flags=0, fragment_duration=0),  # 16 bytes
-                    Container(type="trex", track_ID=1),  # 32 bytes
-                    Container(type="trex", track_ID=2),  # 32 bytes
-                ]))
-            ]))
+            Container(type="moov", data=Container(children=ListContainer([  # 96 bytes
+                Container(type="mvex", data=Container(children=ListContainer([  # 88 bytes
+                    Container(type="mehd", data=Container(version=0, flags=0, fragment_duration=0)),  # 16 bytes
+                    Container(type="trex", data=Container(track_ID=1)),  # 32 bytes
+                    Container(type="trex", data=Container(track_ID=2)),  # 32 bytes
+                ])))
+            ])))
 
         moov_data = Box.build(moov)
 
@@ -116,10 +127,12 @@ class BoxTests(unittest.TestCase):
             Container(
                 offset=0,
                 type="smhd",
-                version=0,
-                flags=0,
-                balance=0,
-                reserved=0,
+                data=Container(
+                    version=0,
+                    flags=0,
+                    balance=0,
+                    reserved=0
+                ),
                 end=len(in_bytes)
             )
         )
@@ -127,7 +140,9 @@ class BoxTests(unittest.TestCase):
     def test_smhd_build(self):
         smhd_data = Box.build(dict(
             type="smhd",
-            balance=0))
+            data=dict(
+                balance=0
+            )))
         self.assertEqual(len(smhd_data), 16),
         self.assertEqual(smhd_data, b'\x00\x00\x00\x10smhd\x00\x00\x00\x00\x00\x00\x00\x00')
 
@@ -139,11 +154,17 @@ class BoxTests(unittest.TestCase):
             Container(
                 offset=0,
                 type="stsd",
-                version=0,
-                flags=0,
-                entries=ListContainer([
-                    Container(format='tx3g', data_reference_index=1, data=tx3g_data)
-                ]),
+                data=Container(
+                    version=0,
+                    flags=0,
+                    entries=ListContainer([
+                        Container(
+                            format="tx3g",
+                            data_reference_index=1,
+                            data=tx3g_data
+                        )
+                    ])
+                ),
                 end=len(in_bytes)
             )
         )

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -17,7 +17,7 @@
 import logging
 import unittest
 
-from construct import Container
+from construct import Container, ListContainer
 from pymp4.parser import Box
 
 log = logging.getLogger(__name__)
@@ -89,13 +89,13 @@ class BoxTests(unittest.TestCase):
 
     def test_moov_build(self):
         moov = \
-            Container(type="moov", children=[  # 96 bytes
-                Container(type="mvex", children=[  # 88 bytes
+            Container(type="moov", children=ListContainer([  # 96 bytes
+                Container(type="mvex", children=ListContainer([  # 88 bytes
                     Container(type="mehd", version=0, flags=0, fragment_duration=0),  # 16 bytes
                     Container(type="trex", track_ID=1),  # 32 bytes
                     Container(type="trex", track_ID=2),  # 32 bytes
-                ])
-            ])
+                ]))
+            ]))
 
         moov_data = Box.build(moov)
 
@@ -141,9 +141,9 @@ class BoxTests(unittest.TestCase):
                 type="stsd",
                 version=0,
                 flags=0,
-                entries=[
+                entries=ListContainer([
                     Container(format='tx3g', data_reference_index=1, data=tx3g_data)
-                ],
+                ]),
                 end=len(in_bytes)
             )
         )

--- a/tests/test_dashboxes.py
+++ b/tests/test_dashboxes.py
@@ -31,12 +31,14 @@ class BoxTests(unittest.TestCase):
             Container(
                 offset=0,
                 type="tenc",
-                version=0,
-                flags=0,
-                is_encrypted=1,
-                iv_size=8,
-                key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
-                constant_iv=None,
+                data=Container(
+                    version=0,
+                    flags=0,
+                    is_encrypted=1,
+                    iv_size=8,
+                    key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
+                    constant_iv=None
+                ),
                 end=32
             )
         )
@@ -45,7 +47,10 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.build(dict(
                 type="tenc",
-                key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
-                iv_size=8,
-                is_encrypted=1)),
+                data=dict(
+                    key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
+                    iv_size=8,
+                    is_encrypted=1
+                )
+            )),
             b'\x00\x00\x00 tenc\x00\x00\x00\x00\x00\x00\x01\x083{\x96C!\xb6CU\x9eY>\xcc\xb4l~\xf7')

--- a/tests/test_dashboxes.py
+++ b/tests/test_dashboxes.py
@@ -28,15 +28,17 @@ class BoxTests(unittest.TestCase):
     def test_tenc_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00 tenc\x00\x00\x00\x00\x00\x00\x01\x083{\x96C!\xb6CU\x9eY>\xcc\xb4l~\xf7'),
-            Container(offset=0)
-            (type="tenc")
-            (version=0)
-            (flags=0)
-            (is_encrypted=1)
-            (iv_size=8)
-            (key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'))
-            (constant_iv=None)
-            (end=32)
+            Container(
+                offset=0,
+                type="tenc",
+                version=0,
+                flags=0,
+                is_encrypted=1,
+                iv_size=8,
+                key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
+                constant_iv=None,
+                end=32
+            )
         )
 
     def test_tenc_build(self):

--- a/tests/test_dashboxes.py
+++ b/tests/test_dashboxes.py
@@ -29,7 +29,7 @@ class BoxTests(unittest.TestCase):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00 tenc\x00\x00\x00\x00\x00\x00\x01\x083{\x96C!\xb6CU\x9eY>\xcc\xb4l~\xf7'),
             Container(offset=0)
-            (type=b"tenc")
+            (type="tenc")
             (version=0)
             (flags=0)
             (is_encrypted=1)
@@ -42,7 +42,7 @@ class BoxTests(unittest.TestCase):
     def test_tenc_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"tenc",
+                type="tenc",
                 key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'),
                 iv_size=8,
                 is_encrypted=1)),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,39 +26,56 @@ log = logging.getLogger(__name__)
 
 
 class BoxTests(unittest.TestCase):
-    box_data = Container(type="demo")(children=[
-            Container(type="a   ")(id=1),
-            Container(type="b   ")(id=2),
-            Container(type="c   ")(children=[
-                Container(type="a   ")(id=3),
-                Container(type="b   ")(id=4),
-            ]),
-            Container(type="d   ")(id=5),
-        ])
+    box_data = Container(
+        type="demo",
+        children=[
+            Container(type="a   ", id=1),
+            Container(type="b   ", id=2),
+            Container(
+                type="c   ",
+                children=[
+                    Container(type="a   ", id=3),
+                    Container(type="b   ", id=4)
+                ]
+            ),
+            Container(type="d   ", id=5)
+        ]
+    )
 
-    box_extended_data = Container(type="test")(children=[
-        Container(type="a   ")(id=1, extended_type=b"e--a"),
-        Container(type="b   ")(id=2, extended_type=b"e--b"),
-    ])
+    box_extended_data = Container(
+        type="test",
+        children=[
+            Container(
+                type="a   ",
+                id=1,
+                extended_type=b"e--a"
+            ),
+            Container(
+                type="b   ",
+                id=2,
+                extended_type=b"e--b"
+            )
+        ]
+    )
 
     def test_find(self):
         self.assertListEqual(
             list(BoxUtil.find(self.box_data, "b   ")),
-            [Container(type="b   ")(id=2), Container(type="b   ")(id=4)]
+            [Container(type="b   ", id=2), Container(type="b   ", id=4)]
         )
 
     def test_find_after_nest(self):
         self.assertListEqual(
             list(BoxUtil.find(self.box_data, "d   ")),
-            [Container(type="d   ")(id=5)]
+            [Container(type="d   ", id=5)]
         )
 
     def test_find_nested_type(self):
         self.assertListEqual(
             list(BoxUtil.find(self.box_data, "c   ")),
-            [Container(type="c   ")(children=[
-                Container(type="a   ")(id=3),
-                Container(type="b   ")(id=4),
+            [Container(type="c   ", children=[
+                Container(type="a   ", id=3),
+                Container(type="b   ", id=4),
             ])]
         )
 
@@ -71,7 +88,7 @@ class BoxTests(unittest.TestCase):
     def test_first(self):
         self.assertEqual(
             BoxUtil.first(self.box_data, "b   "),
-            Container(type="b   ")(id=2)
+            Container(type="b   ", id=2)
         )
 
     def test_first_missing(self):
@@ -83,5 +100,5 @@ class BoxTests(unittest.TestCase):
     def test_find_extended(self):
         self.assertListEqual(
             list(BoxUtil.find_extended(self.box_extended_data, b"e--a")),
-            [Container(type="a   ")(id=1, extended_type=b"e--a")]
+            [Container(type="a   ", id=1, extended_type=b"e--a")]
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,62 +26,62 @@ log = logging.getLogger(__name__)
 
 
 class BoxTests(unittest.TestCase):
-    box_data = Container(type=b"demo")(children=[
-            Container(type=b"a   ")(id=1),
-            Container(type=b"b   ")(id=2),
-            Container(type=b"c   ")(children=[
-                Container(type=b"a   ")(id=3),
-                Container(type=b"b   ")(id=4),
+    box_data = Container(type="demo")(children=[
+            Container(type="a   ")(id=1),
+            Container(type="b   ")(id=2),
+            Container(type="c   ")(children=[
+                Container(type="a   ")(id=3),
+                Container(type="b   ")(id=4),
             ]),
-            Container(type=b"d   ")(id=5),
+            Container(type="d   ")(id=5),
         ])
 
-    box_extended_data = Container(type=b"test")(children=[
-        Container(type=b"a   ")(id=1, extended_type=b"e--a"),
-        Container(type=b"b   ")(id=2, extended_type=b"e--b"),
+    box_extended_data = Container(type="test")(children=[
+        Container(type="a   ")(id=1, extended_type=b"e--a"),
+        Container(type="b   ")(id=2, extended_type=b"e--b"),
     ])
 
     def test_find(self):
         self.assertListEqual(
-            list(BoxUtil.find(self.box_data, b"b   ")),
-            [Container(type=b"b   ")(id=2), Container(type=b"b   ")(id=4)]
+            list(BoxUtil.find(self.box_data, "b   ")),
+            [Container(type="b   ")(id=2), Container(type="b   ")(id=4)]
         )
 
     def test_find_after_nest(self):
         self.assertListEqual(
-            list(BoxUtil.find(self.box_data, b"d   ")),
-            [Container(type=b"d   ")(id=5)]
+            list(BoxUtil.find(self.box_data, "d   ")),
+            [Container(type="d   ")(id=5)]
         )
 
     def test_find_nested_type(self):
         self.assertListEqual(
-            list(BoxUtil.find(self.box_data, b"c   ")),
-            [Container(type=b"c   ")(children=[
-                Container(type=b"a   ")(id=3),
-                Container(type=b"b   ")(id=4),
+            list(BoxUtil.find(self.box_data, "c   ")),
+            [Container(type="c   ")(children=[
+                Container(type="a   ")(id=3),
+                Container(type="b   ")(id=4),
             ])]
         )
 
     def test_find_empty(self):
         self.assertListEqual(
-            list(BoxUtil.find(self.box_data, b"f   ")),
+            list(BoxUtil.find(self.box_data, "f   ")),
             []
         )
 
     def test_first(self):
         self.assertEqual(
-            BoxUtil.first(self.box_data, b"b   "),
-            Container(type=b"b   ")(id=2)
+            BoxUtil.first(self.box_data, "b   "),
+            Container(type="b   ")(id=2)
         )
 
     def test_first_missing(self):
         self.assertRaises(
             BoxNotFound,
-            BoxUtil.first, self.box_data, b"f   ",
+            BoxUtil.first, self.box_data, "f   ",
         )
 
     def test_find_extended(self):
         self.assertListEqual(
             list(BoxUtil.find_extended(self.box_extended_data, b"e--a")),
-            [Container(type=b"a   ")(id=1, extended_type=b"e--a")]
+            [Container(type="a   ")(id=1, extended_type=b"e--a")]
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,7 +17,7 @@
 import logging
 import unittest
 
-from construct import Container
+from construct import Container, ListContainer
 
 from pymp4.exceptions import BoxNotFound
 from pymp4.util import BoxUtil
@@ -28,23 +28,23 @@ log = logging.getLogger(__name__)
 class BoxTests(unittest.TestCase):
     box_data = Container(
         type="demo",
-        children=[
+        children=ListContainer([
             Container(type="a   ", id=1),
             Container(type="b   ", id=2),
             Container(
                 type="c   ",
-                children=[
+                children=ListContainer([
                     Container(type="a   ", id=3),
                     Container(type="b   ", id=4)
-                ]
+                ])
             ),
             Container(type="d   ", id=5)
-        ]
+        ])
     )
 
     box_extended_data = Container(
         type="test",
-        children=[
+        children=ListContainer([
             Container(
                 type="a   ",
                 id=1,
@@ -55,7 +55,7 @@ class BoxTests(unittest.TestCase):
                 id=2,
                 extended_type=b"e--b"
             )
-        ]
+        ])
     )
 
     def test_find(self):
@@ -73,10 +73,10 @@ class BoxTests(unittest.TestCase):
     def test_find_nested_type(self):
         self.assertListEqual(
             list(BoxUtil.find(self.box_data, "c   ")),
-            [Container(type="c   ", children=[
+            [Container(type="c   ", children=ListContainer([
                 Container(type="a   ", id=3),
                 Container(type="b   ", id=4),
-            ])]
+            ]))]
         )
 
     def test_find_empty(self):

--- a/tests/test_webvtt_boxes.py
+++ b/tests/test_webvtt_boxes.py
@@ -12,79 +12,109 @@ class BoxTests(unittest.TestCase):
     def test_iden_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x27iden2 - this is the second subtitle'),
-            Container(offset=0)
-            (type=b"iden")
-            (cue_id="2 - this is the second subtitle")
-            (end=39)
+            Container(
+                offset=0,
+                type="iden",
+                data=Container(
+                    cue_id="2 - this is the second subtitle"
+                ),
+                end=39
+            )
         )
 
     def test_iden_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"iden",
-                cue_id="1 - first subtitle")),
+                type="iden",
+                data=dict(
+                    cue_id="1 - first subtitle"
+                ))),
             b'\x00\x00\x00\x1aiden1 - first subtitle')
 
     def test_sttg_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x003sttgline:10% position:50% size:48% align:center'),
-            Container(offset=0)
-            (type=b"sttg")
-            (settings="line:10% position:50% size:48% align:center")
-            (end=51)
+            Container(
+                offset=0,
+                type="sttg",
+                data=Container(
+                    settings="line:10% position:50% size:48% align:center"
+                ),
+                end=51
+            )
         )
 
     def test_sttg_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"sttg",
-                settings="line:75% position:20% size:2em align:right")),
+                type="sttg",
+                data=dict(
+                    settings="line:75% position:20% size:2em align:right"
+                ))),
             b'\x00\x00\x002sttgline:75% position:20% size:2em align:right')
 
     def test_payl_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x13payl[chuckling]'),
-            Container(offset=0)
-            (type=b"payl")
-            (cue_text="[chuckling]")
-            (end=19)
+            Container(
+                offset=0,
+                type="payl",
+                data=Container(
+                    cue_text="[chuckling]"
+                ),
+                end=19
+            )
         )
 
     def test_payl_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"payl",
-                cue_text="I have a bad feeling about- [boom]")),
+                type="payl",
+                data=dict(
+                    cue_text="I have a bad feeling about- [boom]"
+                ))),
             b'\x00\x00\x00*paylI have a bad feeling about- [boom]')
 
     def test_vttC_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x0evttCWEBVTT'),
-            Container(offset=0)
-            (type=b"vttC")
-            (config="WEBVTT")
-            (end=14)
+            Container(
+                offset=0,
+                type="vttC",
+                data=Container(
+                    config="WEBVTT"
+                ),
+                end=14
+            )
         )
 
     def test_vttC_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"vttC",
-                config="WEBVTT with a text header\n\nSTYLE\n::cue {\ncolor: red;\n}")),
+                type="vttC",
+                data=dict(
+                    config="WEBVTT with a text header\n\nSTYLE\n::cue {\ncolor: red;\n}"
+                ))),
             b'\x00\x00\x00>vttCWEBVTT with a text header\n\nSTYLE\n::cue {\ncolor: red;\n}')
 
     def test_vlab_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x14vlabsource_label'),
-            Container(offset=0)
-            (type=b"vlab")
-            (label="source_label")
-            (end=20)
+            Container(
+                offset=0,
+                type="vlab",
+                data=Container(
+                    label="source_label"
+                ),
+                end=20
+            )
         )
 
     def test_vlab_build(self):
         self.assertEqual(
             Box.build(dict(
-                type=b"vlab",
-                label="1234 \n test_label \n\n")),
+                type="vlab",
+                data=dict(
+                    label="1234 \n test_label \n\n"
+                ))),
             b'\x00\x00\x00\x1cvlab1234 \n test_label \n\n')


### PR DESCRIPTION
> [!NOTE]  
> Update 18th January 2026: I no longer use this package regularly, nor have I for almost a year or more now. This has not been pulled because NEW tests must be made to test various cases that changed or got added through updates to Construct 2.10.x, EXISTING tests must be double checked on various Python versions, and FIXES must be made as showcased by ktp420 and David Buchanan below (and perhaps make tests for cases like this in the future). I do not currently have time to program on my own projects, let alone this one. If anyone can continue the torch so to speak, feel free to continue the work by pushing another PR. 🫡 

> [!IMPORTANT]  
> This has changes to both tests and user code that would be breaking changes. This is not something a user should simply upgrade to without checking and changing code. This WILL break user code. Perhaps a major upgrade is necessary? (4.x). This pull request is based on #9 but with some semantics changed to be as ~~non-breaking as possible~~ (or something at this point).

In this pull request, I've made as few changes to the existing code as possible. I've also reviewed my code multiple times before pushing, unlike in #9 where changes in each commit seem unbalanced, bad commit titles and descriptions, and various debugging code left in.

Breaking changes to users in pymp4 (so far) if pulled:

1. All data in the boxes and the high-level `Box` construct that were parsed as strings, are no longer left as `bytes` type. They are now decoded to unicode strings (i.e., "foo" not b"foo", or "tenc" not b"tenc"). This affects everything from box type, ftyp major_brand, and so on.
2. Since it now uses Construct 2.10, you can no longer define/modify a construct by re-calling the constructor of the constructor return, because it no longer returns the constructor like that. I.e., you must now do:

```py
Container(
    offset=0,
    type="ftyp",
    major_brand="iso5",
    minor_version=1,
    compatible_brands=["iso5", "avc1"],
    end=24
)
```

Instead of:

```py
Container(offset=0)
  (type="ftyp")
  (major_brand="iso5")
  (minor_version=1)
  (compatible_brands=["iso5", "avc1"])
  (end=24)
```
3. All custom adapters have been moved from `parser.py` to `adapters.py`.
4. TellMinusSizeOf is now TellPlusSizeOf and has been moved from `parser.py` to `subconstructs.py`.
5. All boxes field's are now nested within a `data` field. This was simply a requirement. I could not think of any way to embedded the box fields, nor can the maintainer of construct when asked. It seems to simply be a completely pulled feature that will not return. This means all user code that accesses fields must be updated from e.g., `tenc_box.is_encrypted` to `tenc_box.data.is_encrypted`.
6. All boxes had the type field removed from their individual structs. It is unnecessary as the length information isn't prefixed on them, so they were more or less already risky to use manually/outside of the Box struct. This was required so as to not duplicate the type in the Box container and the Box's `data` field container.
7. All EmbeddedBitStruct and Embedded(BitStruct()) fields were nested under a "flags" field. This has the same ramifications as change 5.
8. The ISO6392TLanguageCode Adapter has been reworked to expect an Int16 input as obj, which will then do Bitwise operations on it itself. This was so we don't need to nest the parsed Language Code under another field (i.e., `box.language.code` like #9 did).

If you have any ideas for improvements or want to change how those "data"/"flags" fields are named or function, feel free to. Sadly I could not find anything better.

**All tests pass on Python 3.10.**

```
(pymp4-py3.10) PS C:\Users\rlaphoenix\Projects\pymp4> python -m pytest tests/
================================= test session starts ==================================
platform win32 -- Python 3.10.10, pytest-7.0.1, pluggy-1.0.0
rootdir: C:\Users\rlaphoenix\Projects\pymp4
plugins: cov-4.0.0
collected 17 items                                                                      

tests\test_box.py ........                                                        [ 47%]
tests\test_dashboxes.py ..                                                        [ 58%]
tests\test_util.py .......                                                        [100%]

================================== 17 passed in 0.09s ==================================
```

Closes #23 and #3 