### PR TITLE
Correctly define _reserved1 in tenc box and improve it's Const checks

### DIFF
--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -694,12 +694,12 @@ ProtectionSystemHeaderBox = Struct(
 
 TrackEncryptionBox = Struct(
     "type" / If(this._.type != b"uuid", Const(b"tenc")),
-    "version" / Default(Int8ub, 0),
+    "version" / Default(OneOf(Int8ub, (0, 1)), 0),
     "flags" / Default(Int24ub, 0),
     "_reserved0" / Const(Int8ub, 0),
     "_reserved1" / Const(Int8ub, 0),
-    "is_encrypted" / Int8ub,
-    "iv_size" / Int8ub,
+    "is_encrypted" / OneOf(Int8ub, (0, 1)),
+    "iv_size" / OneOf(Int8ub, (0, 8, 16)),
     "key_ID" / UUIDBytes(Bytes(16)),
     "constant_iv" / Default(If(this.is_encrypted and this.iv_size == 0,
                                PrefixedArray(Int8ub, Byte),

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -710,11 +710,10 @@ TrackEncryptionBox = Struct(
     "is_encrypted" / OneOf(Int8ub, (0, 1)),
     "iv_size" / OneOf(Int8ub, (0, 8, 16)),
     "key_ID" / UUIDBytes(Bytes(16)),
-    "constant_iv" / Default(If(this.is_encrypted and this.iv_size == 0,
-                               PrefixedArray(Int8ub, Byte),
-                               ),
-                            None)
-
+    "constant_iv" / Default(If(
+        this.is_encrypted and this.iv_size == 0,
+        PrefixedArray(Int8ub, Byte)
+    ), None)
 )
 
 SampleEncryptionBox = Struct(

--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -696,8 +696,17 @@ TrackEncryptionBox = Struct(
     "type" / If(this._.type != b"uuid", Const(b"tenc")),
     "version" / Default(OneOf(Int8ub, (0, 1)), 0),
     "flags" / Default(Int24ub, 0),
-    "_reserved0" / Const(Int8ub, 0),
-    "_reserved1" / Const(Int8ub, 0),
+    "_reserved" / Const(Int8ub, 0),
+    "default_byte_blocks" / Default(IfThenElse(
+        this.version > 0,
+        BitStruct(
+            # count of encrypted blocks in the protection pattern, where each block is 16-bytes
+            "crypt" / Nibble,
+            # count of unencrypted blocks in the protection pattern
+            "skip" / Nibble
+        ),
+        Const(Int8ub, 0)
+    ), 0),
     "is_encrypted" / OneOf(Int8ub, (0, 1)),
     "iv_size" / OneOf(Int8ub, (0, 8, 16)),
     "key_ID" / UUIDBytes(Bytes(16)),

--- a/tests/test_dashboxes.py
+++ b/tests/test_dashboxes.py
@@ -32,6 +32,8 @@ class BoxTests(unittest.TestCase):
             (type=b"tenc")
             (version=0)
             (flags=0)
+            (_reserved=0)
+            (default_byte_blocks=0)
             (is_encrypted=1)
             (iv_size=8)
             (key_ID=UUID('337b9643-21b6-4355-9e59-3eccb46c7ef7'))


### PR DESCRIPTION
You defined _reserved1 as a Const byte, when in fact it's not. For v0 tenc boxes, it is. But not for v1 tenc boxes which use pattern-based decision-making for the Key ID and IV stuff. Therefore I've implemented the necessary changes to fully support v1 tenc boxes.

This fixes #29 

Tests are successful (on Python 3.9 and older, see #23).

![image](https://user-images.githubusercontent.com/17136956/233861683-78a5b270-1827-4bd0-ad49-3904fe091e5a.png)
