### PR TITLE
Add sample_info to MP4ASampleEntryBox

### DIFF
--- a/src/pymp4/parser.py
+++ b/src/pymp4/parser.py
@@ -321,7 +321,8 @@ MP4ASampleEntryBox = Struct(
     "compression_id" / Default(Int16sb, 0),
     "packet_size" / Const(Int16ub, 0),
     "sampling_rate" / Int16ub,
-    Padding(2)
+    Padding(2),
+    "sample_info" / LazyBound(lambda _: GreedyRange(Box))
 )
 
 


### PR DESCRIPTION
This is similar to [`sample_info`](https://github.com/beardypig/pymp4/blob/427f232beb326c07a1035d7bd8ff6e05049b76e9/src/pymp4/parser.py#L402) in [`AVC1SampleEntryBox`](https://github.com/beardypig/pymp4/blob/427f232beb326c07a1035d7bd8ff6e05049b76e9/src/pymp4/parser.py#L378-L403).
